### PR TITLE
Removing unused package from collate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,5 @@ Collate:
     'roleModel.R'
     'roleR-package.R'
     'roleSim.R'
-    'roleSimOld.R'
     'roleSimPlots.R'
     'speciation.R'


### PR DESCRIPTION
'roleSimOld.R' package entry in collate causes breaking of installation of packages. 

error faced - 

```
#17 120.4 Error in .install_package_code_files(".", instdir) :
#17 120.4 files in 'Collate' field missing from '/tmp/RtmpXXN1Nq/R.INSTALL46d16554ae3/roleR/R':
#17 120.4   roleSimOld.R
#17 120.4 ERROR: unable to collate and parse R files for package ‘roleR’
#17 120.4 * removing ‘/usr/local/lib/R/site-library/roleR’
#17 120.6 Error: Failed to install 'roleR' from GitHub:
#17 120.6   (converted from warning) installation of package ‘/tmp/RtmpUgrVLL/filea9fffa2d/roleR_0.1.0.tar.gz’ had non-zero exit status
#17 120.6 Execution halted
------
executor failed running [/bin/sh -c Rscript /home/script/install_packages.R]: exit code: 1
```